### PR TITLE
feat(ComponentExample): instantiate vanilla components

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -88,18 +88,6 @@ exports.onCreateWebpackConfig = ({
   actions,
 }) => {
   actions.setWebpackConfig({
-    entry: {
-      main: [require.resolve('react-dev-utils/webpackHotDevClient'), paths.appIndexJs],
-      'carbon-components': paths.carbonComponentsIndexJs,
-    },
-    output: {
-      path: paths.appBuild,
-      pathinfo: true,
-      filename: 'static/js/[name].js',
-      publicPath: publicPath,
-      library: ['CDS', '[name]'],
-      libraryTarget: 'var',
-    },
     module: {
       rules: [
         {

--- a/src/components/ComponentExample/ComponentExample.js
+++ b/src/components/ComponentExample/ComponentExample.js
@@ -69,6 +69,13 @@ class ComponentExample extends Component {
     this._releaseAndInstantiateComponents();
   };
 
+  componentDidUpdate({ htmlFile }) {
+    const { prevHtmlFile } = this.props;
+    if (prevHtmlFile !== htmlFile) {
+      this._releaseAndInstantiateComponents();
+    }
+  }
+
   _releaseAndInstantiateComponents() {
     const instances = this._instances;
     for (let instance = instances.pop(); instance; instance = instances.pop()) {

--- a/src/polyfills/custom-event.js
+++ b/src/polyfills/custom-event.js
@@ -1,0 +1,14 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import CustomEventPolyfill from 'custom-event';
+
+// eslint-disable-next-line consistent-return
+const missingNativeCustomEvent = (() => {
+  try {
+    new CustomEvent('test-event'); // eslint-disable-line no-new
+  } catch (error) {
+    return true;
+  }
+})();
+if (missingNativeCustomEvent) {
+  window.CustomEvent = CustomEventPolyfill;
+}

--- a/src/polyfills/element-closest.js
+++ b/src/polyfills/element-closest.js
@@ -1,0 +1,11 @@
+if (typeof Element.prototype.closest !== 'function') {
+  Element.prototype.closest = function closestElement(selector) {
+    const doc = this.ownerDocument;
+    for (let traverse = this; traverse && traverse !== doc; traverse = traverse.parentNode) {
+      if (traverse.matches(selector)) {
+        return traverse;
+      }
+    }
+    return null;
+  };
+}

--- a/src/polyfills/element-matches.js
+++ b/src/polyfills/element-matches.js
@@ -1,0 +1,7 @@
+const matchesFuncName = ['matches', 'webkitMatchesSelector', 'msMatchesSelector'].filter(
+  name => typeof Element.prototype[name] === 'function'
+)[0];
+
+if (matchesFuncName !== 'matches') {
+  Element.prototype.matches = Element.prototype[matchesFuncName];
+}

--- a/src/polyfills/index.js
+++ b/src/polyfills/index.js
@@ -1,0 +1,16 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import 'core-js/modules/es6.array.fill';
+import 'core-js/modules/es6.array.from';
+import 'core-js/modules/es7.array.includes';
+import 'core-js/modules/es6.math.sign';
+import 'core-js/modules/es6.object.assign';
+import 'core-js/modules/es7.object.values';
+import 'core-js/modules/es6.promise.js';
+import 'core-js/modules/es6.string.includes';
+import 'core-js/modules/es6.string.trim';
+/* eslint-enable import/no-extraneous-dependencies */
+
+import './custom-event';
+import './element-closest';
+import './element-matches';
+import './toggle-class';

--- a/src/polyfills/toggle-class.js
+++ b/src/polyfills/toggle-class.js
@@ -1,0 +1,16 @@
+const missingNativeDOMTokenListToggleForce = (() => {
+  const elem = document.createElement('div');
+  const randomClass = `_random_class_${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  elem.classList.toggle(randomClass, false);
+  return elem.classList.contains(randomClass);
+})();
+if (missingNativeDOMTokenListToggleForce) {
+  (() => {
+    const origToggle = DOMTokenList.prototype.toggle;
+    DOMTokenList.prototype.toggle = function toggleDOMTokenList(name, add) {
+      return arguments.length < 2 || this.contains(name) === !add ? origToggle.call(this, name) : add;
+    };
+  })();
+}


### PR DESCRIPTION
Brought (back) in some code from the original Carbon site code.

I initially tried the approach of using `CDS` global like current Carbon site code does, but took an alternate approach (using equivalent ESM import) as Gatsby ignores our WebPack config that create `CDS` global.