### PR TITLE
fix(config): IE11 fixes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -84,12 +84,25 @@ exports.createPages = ({ actions, graphql }) => {
   });
 };
 
-exports.onCreateWebpackConfig = ({
-  actions,
-}) => {
-  actions.setWebpackConfig({
+exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
+  const config = getConfig();
+  const { module } = config;
+  const { rules } = module;
+  actions.replaceWebpackConfig({
+    ...config,
     module: {
+      ...module,
       rules: [
+        ...rules.map(item => {
+          const { use } = item;
+          if (!use || use.every(({ loader }) => !/babel-loader\.js$/i.test(loader))) {
+            return item;
+          }
+          return {
+            ...item,
+            exclude: /(node_modules|bower-components)[\/\\](?!(ansi-regex)[\/\\]).*/,
+          };
+        }),
         {
           test: /\.md$/,
           loaders: ['html-loader', 'markdown-loader'],
@@ -103,5 +116,5 @@ exports.onCreateWebpackConfig = ({
         },
       ],
     },
-  })
-}
+  });
+};

--- a/src/components/ComponentExample/ComponentExample.js
+++ b/src/components/ComponentExample/ComponentExample.js
@@ -4,7 +4,6 @@ import classnames from 'classnames';
 import CodeExample from '../CodeExample/CodeExample';
 import * as components from 'carbon-components/es/globals/js/components';
 import { RadioButtonGroup, RadioButton } from 'carbon-components-react';
-import '../../polyfills';
 
 const componentNamesMap = {
   Card: ['OverflowMenu'],

--- a/src/polyfills/custom-event.js
+++ b/src/polyfills/custom-event.js
@@ -9,6 +9,6 @@ const missingNativeCustomEvent = (() => {
     return true;
   }
 })();
-if (missingNativeCustomEvent) {
+if (missingNativeCustomEvent && typeof window !== 'undefined') {
   window.CustomEvent = CustomEventPolyfill;
 }

--- a/src/polyfills/element-closest.js
+++ b/src/polyfills/element-closest.js
@@ -1,4 +1,4 @@
-if (typeof Element.prototype.closest !== 'function') {
+if (typeof Element !== 'undefined' && typeof Element.prototype.closest !== 'function') {
   Element.prototype.closest = function closestElement(selector) {
     const doc = this.ownerDocument;
     for (let traverse = this; traverse && traverse !== doc; traverse = traverse.parentNode) {

--- a/src/polyfills/element-matches.js
+++ b/src/polyfills/element-matches.js
@@ -1,7 +1,9 @@
-const matchesFuncName = ['matches', 'webkitMatchesSelector', 'msMatchesSelector'].filter(
-  name => typeof Element.prototype[name] === 'function'
-)[0];
-
-if (matchesFuncName !== 'matches') {
-  Element.prototype.matches = Element.prototype[matchesFuncName];
+if (typeof Element !== 'undefined') {
+  const matchesFuncName = ['matches', 'webkitMatchesSelector', 'msMatchesSelector'].filter(
+    name => typeof Element.prototype[name] === 'function'
+  )[0];
+  
+  if (matchesFuncName !== 'matches') {
+    Element.prototype.matches = Element.prototype[matchesFuncName];
+  }
 }

--- a/src/polyfills/toggle-class.js
+++ b/src/polyfills/toggle-class.js
@@ -1,16 +1,18 @@
-const missingNativeDOMTokenListToggleForce = (() => {
-  const elem = document.createElement('div');
-  const randomClass = `_random_class_${Math.random()
-    .toString(36)
-    .slice(2)}`;
-  elem.classList.toggle(randomClass, false);
-  return elem.classList.contains(randomClass);
-})();
-if (missingNativeDOMTokenListToggleForce) {
-  (() => {
-    const origToggle = DOMTokenList.prototype.toggle;
-    DOMTokenList.prototype.toggle = function toggleDOMTokenList(name, add) {
-      return arguments.length < 2 || this.contains(name) === !add ? origToggle.call(this, name) : add;
-    };
+if (typeof DOMTokenList !== 'undefined') {
+  const missingNativeDOMTokenListToggleForce = (() => {
+    const elem = document.createElement('div');
+    const randomClass = `_random_class_${Math.random()
+      .toString(36)
+      .slice(2)}`;
+    elem.classList.toggle(randomClass, false);
+    return elem.classList.contains(randomClass);
   })();
+  if (missingNativeDOMTokenListToggleForce) {
+    (() => {
+      const origToggle = DOMTokenList.prototype.toggle;
+      DOMTokenList.prototype.toggle = function toggleDOMTokenList(name, add) {
+        return arguments.length < 2 || this.contains(name) === !add ? origToggle.call(this, name) : add;
+      };
+    })();
+  }
 }

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -1,3 +1,4 @@
+import '../polyfills';
 import React from 'react';
 import rehypeReact from 'rehype-react';
 import Layout from "../components/layouts";


### PR DESCRIPTION
Refs #24.

Does a few things:

1. Changed the `excludes` option of `babel-loader`. [`ansi-regex`](https://www.npmjs.com/package/ansi-regex) module seems to be loaded in this app. That module has `const` which cannot be parsed by IE11 and thus needs to be transpiled.
2. A change as an attempt to load our polyfills at the top-level
3. Check for web platform globals to cope with Gatsby SSR