### PR TITLE
Add experimental color page

### DIFF
--- a/src/content/experimental/color/color.md
+++ b/src/content/experimental/color/color.md
@@ -16,7 +16,7 @@ title: Color
 <color-card name="ui-05" hex="#171717"></color-card>
 <color-card name="text-01" hex="#171717"></color-card>
 <color-card name="text-02" hex="#565656"></color-card>
-<color-card name="text-03" hex="#a4a4a4"></color-card>
+<color-card name="text-03" hex="#8c8c8c"></color-card>
 <color-card name="inverse-01" hex="#ffffff" border="true"></color-card>
 <color-card name="field-01" hex="#f2f4f8"></color-card>
 </flex-group>

--- a/src/content/experimental/color/color.md
+++ b/src/content/experimental/color/color.md
@@ -1,0 +1,41 @@
+---
+label: Experimental
+title: Color
+---
+
+## Experimental theme
+
+<flex-group>
+<color-card name="brand-01" hex="#0062ff"></color-card>
+<color-card name="brand-02" hex="#0530ad"></color-card>
+<color-card name="brand-03" hex="#0062ff"></color-card>
+<color-card name="ui-01" hex="#f3f3f3"></color-card>
+<color-card name="ui-02" hex="#ffffff" border="true"></color-card>
+<color-card name="ui-03" hex="#dcdcdc"></color-card>
+<color-card name="ui-04" hex="#8c8c8c"></color-card>
+<color-card name="ui-05" hex="#171717"></color-card>
+<color-card name="text-01" hex="#171717"></color-card>
+<color-card name="text-02" hex="#565656"></color-card>
+<color-card name="text-03" hex="#a4a4a4"></color-card>
+<color-card name="inverse-01" hex="#ffffff" border="true"></color-card>
+<color-card name="field-01" hex="#f2f4f8"></color-card>
+</flex-group>
+
+### Hover Colors 
+
+<flex-group>
+<color-card name="hover-primary" hex="#004ecc"></color-card>
+<color-card name="hover-primary-text" hex="#0045b3"></color-card>
+<color-card name="hover-danger" hex="#ad1820"></color-card>
+<color-card name="hover-secondary" hex="#0062ff"></color-card>
+<color-card name="hover-row" hex="rgba(5, 48, 173, 0.1)"></color-card>
+</flex-group>
+
+### Support Colors
+
+<flex-group>
+<color-card name="support-01" hex="#da1e28"></color-card>
+<color-card name="support-02" hex="#24a249"></color-card>
+<color-card name="support-03" hex="#fdd13a"></color-card>
+<color-card name="support-04" hex="#418cff"></color-card>
+</flex-group>

--- a/src/data/navigation/navigation.json
+++ b/src/data/navigation/navigation.json
@@ -187,6 +187,9 @@
       "about": {
         "title": "About"
       },
+      "color": {
+        "title": "Color"
+      },
       "checkbox": {
         "title": "Checkbox"
       },


### PR DESCRIPTION
closes #73 

This uses the values for the color tokens we have been using to build experimental components at this point (and what we had defined in the experimental theme)

<img width="937" alt="screen shot 2018-09-20 at 5 06 20 pm" src="https://user-images.githubusercontent.com/2753488/45849595-27c60400-bcf8-11e8-88d7-98f4bd78fe47.png">
 @jeoffw 👆