### PR TITLE
ci: revert internal deployments and add docs for deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
               # Install `ibmcloud` CLI
               curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
 
+              ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+              ibmcloud cf install-plugin blue-green-deploy -r CF-Community
+
               # Login and push staging manifest
               ibmcloud login \
                 --apikey $CLOUD_API_KEY \
@@ -26,21 +29,7 @@ jobs:
                 -o carbon-design-system \
                 -s production
 
-              ibmcloud cf push -f .circleci/manifest.staging.yml
-
-              # Build and deploy internal site
-              yarn build:internal
-
-              ibmcloud login \
-                --apikey $INTERNAL_CLOUD_API_KEY \
-                -a https://api.stage1.ng.bluemix.net \
-                -o 'carbon@us.ibm.com' \
-                -s production
-
-              ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-              ibmcloud cf install-plugin blue-green-deploy -r CF-Community
-
-              ibmcloud cf blue-green-deploy carbon-website-internal \
-                -f .circleci/manifest.internal.yml \
+              ibmcloud cf blue-green-deploy carbon-website-staging \
+                -f .circleci/manifest.staging.yml \
                 --delete-old-apps
             fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,23 @@
+# Deployments
+
+## Internal
+
+```bash
+# Build the internal site
+yarn build:internal
+
+ibmcloud login \
+  --sso
+  -a https://api.stage1.ng.bluemix.net \
+  -o 'carbon@us.ibm.com' \
+  -s production
+
+# Make sure you have blue-green-deploy installed as a plugin for cf
+ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+ibmcloud cf install-plugin blue-green-deploy -r CF-Community
+
+# Deploy the internal website
+ibmcloud cf blue-green-deploy carbon-website-internal \
+  -f .circleci/manifest.internal.yml \
+  --delete-old-apps
+```


### PR DESCRIPTION
Reverts internal deployments and adds in docs as a replacement.