### PR TITLE
hide clickable area when menu is closed

### DIFF
--- a/src/components/SideNav/side-nav.scss
+++ b/src/components/SideNav/side-nav.scss
@@ -55,6 +55,10 @@
   }
 }
 
+.side-nav-click-to-close__closed {
+  display: none;
+}
+
 //===================
 // SIDE NAV LOGO
 //===================


### PR DESCRIPTION
can't interact with elements on the page on mobile because clickable area sits on top. this hides it when the menu is closed. 