### PR TITLE
Text format

### DIFF
--- a/docs/CONTENT.md
+++ b/docs/CONTENT.md
@@ -71,8 +71,9 @@ You can create an inline link by wrapping link text in brackets [ ], and then wr
 
 `[Carbon](http://www.carbondesignsystem.com/)`
 
-If you need a link to open in a new window you will have to use standard html. You will also need to wrap the block of text in either a `<p>` or `<li>` tag.
-`<p>This is a link to <a href="http://www.carbondesignsystem.com" target="_blank">Carbon</a></p>`
+If you need a link to open in a new window you will have to use standard html to target the new window.
+
+`<a href="http://www.carbondesignsystem.com" target="_blank">Carbon</a></p>`
 
 ### Images
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -352,60 +352,61 @@ class IndexPage extends React.Component {
                 <Link
                   to="/getting-started"
                   aria-label="Getting started"
-                  className="list-item__icon">
+                  className="list-item__link">
                   <img src={gettingStartedIll} alt="" />
+                
+                  <div className="list-item__info">
+                    <span className="list-item__heading">Getting Started</span>
+                    <p>
+                      Onboarding for designers and developers who are using Carbon
+                      for the first time.
+                    </p>
+                  </div>
                 </Link>
-                <div className="list-item__info">
-                  <Link to="/getting-started/designers">Getting Started</Link>
-                  <p>
-                    Onboarding for designers and developers who are using Carbon
-                    for the first time.
-                  </p>
-                </div>
               </li>
               <li className="overview-page__list-item">
                 <Link
                   to="/style"
                   aria-label="Style"
-                  className="list-item__icon">
+                  className="list-item__link">
                   <img src={styleIll} alt="" />
+                  <div className="list-item__info">
+                    <span className="list-item__heading">Guidelines</span>
+                    <p>
+                      Guidance on usage and application for basic design elements.
+                    </p>
+                  </div>
                 </Link>
-                <div className="list-item__info">
-                  <Link to="/guidelines/color/swatches">Guidelines</Link>
-                  <p>
-                    Guidance on usage and application for basic design elements.
-                  </p>
-                </div>
               </li>
               <li className="overview-page__list-item">
                 <Link
                   to="/components"
                   aria-label="Components"
-                  className="list-item__icon">
+                  className="list-item__link">
                   <img src={componentsIll} alt="" />
+                  <div className="list-item__info">
+                    <span className="list-item__heading">Components</span>
+                    <p>
+                      A library of all Carbon components, comprised of code, usage
+                      and style guidelines.
+                    </p>
+                  </div>
                 </Link>
-                <div className="list-item__info">
-                  <Link to="/components/overview">Components</Link>
-                  <p>
-                    A library of all Carbon components, comprised of code, usage
-                    and style guidelines.
-                  </p>
-                </div>
               </li>
               <li className="overview-page__list-item">
                 <Link
                   to="/resources"
                   aria-label="Resources"
-                  className="list-item__icon">
+                  className="list-item__link">
                   <img src={resourcesIll} alt="" />
+                  <div className="list-item__info">
+                    <span className="list-item__heading">Resources</span>
+                    <p>
+                      A helpful list of tools, links and downloads that will
+                      improve a Carbon user's workflow.
+                    </p>
+                  </div>
                 </Link>
-                <div className="list-item__info">
-                  <Link to="/resources">Resources</Link>
-                  <p>
-                    A helpful list of tools, links and downloads that will
-                    improve a Carbon user's workflow.
-                  </p>
-                </div>
               </li>
             </ul>
           </section>

--- a/src/styles/_home.scss
+++ b/src/styles/_home.scss
@@ -247,15 +247,16 @@
   }
 }
 
-.list-item__icon {
+.list-item__link {
+  display: flex;
+  text-decoration: none;
+}
+
+.list-item__link img{
   width: 100px;
   height: 100px;
   margin-right: 1.5rem;
   flex-shrink: 0;
-
-  img {
-    width: 100%;
-  }
 
   @media all and (max-width: 1260px) {
     margin-bottom: 1.5rem;
@@ -268,6 +269,7 @@
   flex-direction: column;
   align-items: flex-start;
   max-width: 300px;
+  text-decoration: none;
 
   @media all and (max-width: 1270px) {
     margin-left: 1rem;
@@ -279,7 +281,7 @@
     text-align: center;
   }
 
-  a {
+  .list-item__heading {
     @include typescale('alpha');
     text-decoration: none;
     color: $text-01;
@@ -297,6 +299,7 @@
   p {
     @include typescale('zeta');
     line-height: 1.5;
+    color: $text-01;
 
     @media all and (max-width: 600px) {
       @include typescale('epsilon');

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -47,12 +47,13 @@ body {
   }
 
   // All paragraphs on Markdown pages
-  p {
+  // And divs when markdown doesn't wrap text in paragraphs (when you have to use html for links to open in a new window)
+  p,
+  & > div > div {
     max-width: 38rem;
     line-height: 1.5;
     padding: 0 0 $spacing-md;
   }
-
 
   // All em on Markdown pages
   em {


### PR DESCRIPTION
When you use regular html for a link inside markdown it doesn't generate a `<p>` tag so the correct styling wasn't being applied. This adds the styling to fix that.

Also updates homepage link to remove double links https://github.com/IBM/design-system-website/issues/262